### PR TITLE
Improve component reconciler removal

### DIFF
--- a/docs/registration.md
+++ b/docs/registration.md
@@ -71,7 +71,7 @@ Customization is being worked on, A checkbox indicates if the feature is availab
 
 ### Add New Parameters
 
-- [ ] Create new parameter with literal value
+- [x] Create new parameter with literal value
 
 ```yaml
     parameterConfiguration:
@@ -218,9 +218,3 @@ kubectl apply -f https://github.com/triggermesh/scoby/tree/main/docs/samples/01.
 ```
 
 Kuard is an application created by the authors of Kubernetes Up and Ready book that is able to render a list of its environment variables. Our registration uses the Kuard image and a list of elements at the spec to demonstrate how to render them as environment variables in different ways.
-
-### Example with URL resolving
-
-A registered object is able to resolve a kubernetes object into a URL and use the result as an environment variable.
-
-// TODO

--- a/pkg/reconciler/component/reconciler/builder.go
+++ b/pkg/reconciler/component/reconciler/builder.go
@@ -9,7 +9,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/triggermesh/scoby/pkg/apis/scoby.triggermesh.io/common"
 	"github.com/triggermesh/scoby/pkg/reconciler/component/reconciler/base"
@@ -22,7 +21,7 @@ const (
 	defaultContainerName = "adapter"
 )
 
-func NewReconciler(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, reg common.Registration, mgr manager.Manager) (reconcile.Reconciler, error) {
+func NewReconciler(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, reg common.Registration, mgr manager.Manager) (chan error, error) {
 	wkl := reg.GetWorkload()
 	resolver := resolver.New(mgr.GetClient())
 	renderer := base.NewRenderer(defaultContainerName, wkl.FromImage.Repo, wkl.ParameterConfiguration, resolver)


### PR DESCRIPTION
Component reconciler is registered unmanaged, a custom context per reconciler is controlling its lifecycle, which is not managed by the registry.

Shutdown of individual components reconcilers or the main Scoby is now attemted gracefully and timesout after 5 seconds.