### PR TITLE
Hooks: manage finalizers when hook is present

### DIFF
--- a/pkg/hook/v1/types.go
+++ b/pkg/hook/v1/types.go
@@ -20,7 +20,7 @@ type HookRequest struct {
 
 // HookResponse is the expected reply from configured hooks.
 type HookResponse struct {
-	Status HookStatus `json:"status"`
+	Status *HookStatus `json:"status"`
 
 	// EnvVars contains parameters to be added to the workload.
 	EnvVars []corev1.EnvVar `json:"addEnvs,omitempty"`

--- a/pkg/reconciler/component/reconciler/base/reconciler.go
+++ b/pkg/reconciler/component/reconciler/base/reconciler.go
@@ -11,6 +11,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -18,6 +19,10 @@ import (
 	commonv1alpha1 "github.com/triggermesh/scoby/pkg/apis/common/v1alpha1"
 	"github.com/triggermesh/scoby/pkg/reconciler/component/reconciler"
 	"github.com/triggermesh/scoby/pkg/reconciler/semantic"
+)
+
+const (
+	componentFinalizer = "scoby.triggermesh.io/finalizer"
 )
 
 func NewController(
@@ -74,8 +79,21 @@ func (b *base) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, er
 	b.log.V(5).Info("Object retrieved", "object", obj)
 
 	if !obj.GetDeletionTimestamp().IsZero() {
-		if b.hookReconciler != nil {
-			_ = b.hookReconciler.Finalize(ctx, obj)
+		if b.hookReconciler != nil && b.hookReconciler.IsFinalizer() {
+
+			err := b.hookReconciler.Finalize(ctx, obj)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			if !controllerutil.ContainsFinalizer(obj, componentFinalizer) {
+				return ctrl.Result{}, nil
+			}
+
+			// Removing the finalizer must succeed so that
+			// the registration is deleted.
+			controllerutil.RemoveFinalizer(obj, componentFinalizer)
+			return ctrl.Result{}, b.client.Update(ctx, obj.AsKubeObject())
 		}
 
 		// Return and let the ownership clean resources.
@@ -87,9 +105,20 @@ func (b *base) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, er
 	cp := obj.AsKubeObject().DeepCopyObject()
 
 	if b.hookReconciler != nil {
-		err := b.hookReconciler.Reconcile(ctx, obj)
-		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("reconciling hook: %w", err)
+		if b.hookReconciler.IsReconciler() {
+			if err := b.hookReconciler.Reconcile(ctx, obj); err != nil {
+				return ctrl.Result{}, fmt.Errorf("reconciling hook: %w", err)
+			}
+		}
+		if b.hookReconciler.IsFinalizer() {
+			// Set the finalizer if it is not present
+			if !controllerutil.ContainsFinalizer(obj, componentFinalizer) {
+				controllerutil.AddFinalizer(obj.AsKubeObject(), componentFinalizer)
+				if err := b.client.Update(ctx, obj.AsKubeObject()); err != nil {
+					return ctrl.Result{}, err
+				}
+
+			}
 		}
 	}
 

--- a/pkg/reconciler/component/reconciler/base/reconciler.go
+++ b/pkg/reconciler/component/reconciler/base/reconciler.go
@@ -112,9 +112,10 @@ func (b *base) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, er
 		}
 		if b.hookReconciler.IsFinalizer() {
 			// Set the finalizer if it is not present
-			if !controllerutil.ContainsFinalizer(obj, componentFinalizer) {
-				controllerutil.AddFinalizer(obj.AsKubeObject(), componentFinalizer)
-				if err := b.client.Update(ctx, obj.AsKubeObject()); err != nil {
+			objk := obj.AsKubeObject()
+			if !controllerutil.ContainsFinalizer(objk, componentFinalizer) {
+				controllerutil.AddFinalizer(objk, componentFinalizer)
+				if err := b.client.Update(ctx, objk); err != nil {
 					return ctrl.Result{}, err
 				}
 

--- a/pkg/reconciler/component/reconciler/hook/reconciler.go
+++ b/pkg/reconciler/component/reconciler/hook/reconciler.go
@@ -16,7 +16,8 @@ import (
 )
 
 type hookReconciler struct {
-	url string
+	url         string
+	isFinalizer bool
 
 	log logr.Logger
 }
@@ -26,6 +27,12 @@ func New(h *commonv1alpha1.Hook, url string, log logr.Logger) reconciler.HookRec
 	hr := &hookReconciler{
 		url: url,
 		log: log,
+		// by default finalization is considered implemented.
+		isFinalizer: true,
+	}
+
+	if h.Finalization != nil && !*h.Finalization.Enabled {
+		hr.isFinalizer = false
 	}
 
 	return hr
@@ -33,6 +40,32 @@ func New(h *commonv1alpha1.Hook, url string, log logr.Logger) reconciler.HookRec
 
 func (hr *hookReconciler) Reconcile(ctx context.Context, obj reconciler.Object) error {
 	hr.log.V(1).Info("Reconciling at hook", "obj", obj)
+
+	res, err := hr.requestHook(ctx, hookv1.OperationReconcile, obj)
+	if err != nil {
+		return err
+	}
+
+	// TODO use status and env vars
+	hr.log.V(5).Info("Response received from hook", "response", *res)
+
+	return nil
+}
+
+func (hr *hookReconciler) Finalize(ctx context.Context, obj reconciler.Object) error {
+	hr.log.V(1).Info("Finalizing at hook", "obj", obj)
+
+	hr.log.Info("DEBUG DELETEME calling hook at finalize hook", "obj", obj)
+	if _, err := hr.requestHook(ctx, hookv1.OperationFinalize, obj); err != nil {
+		hr.log.Info("DEBUG DELETEME there was an error at finalize hook", "obj", obj)
+		return err
+	}
+	hr.log.Info("DEBUG DELETEME done at finalize hook", "obj", obj)
+
+	return nil
+}
+
+func (hr *hookReconciler) requestHook(ctx context.Context, operation hookv1.Operation, obj reconciler.Object) (*hookv1.HookResponse, error) {
 	r := &hookv1.HookRequest{
 		Object: commonv1alpha1.Reference{
 			APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
@@ -40,23 +73,23 @@ func (hr *hookReconciler) Reconcile(ctx context.Context, obj reconciler.Object) 
 			Namespace:  obj.GetNamespace(),
 			Name:       obj.GetName(),
 		},
-		Operation: hookv1.OperationReconcile,
+		Operation: operation,
 	}
 	b, err := json.Marshal(r)
 	if err != nil {
-		return fmt.Errorf("could not marshal hook request: %w", err)
+		return nil, fmt.Errorf("could not marshal hook request: %w", err)
 	}
 
 	req, err := http.NewRequest("POST", hr.url, bytes.NewBuffer(b))
 	if err != nil {
-		return fmt.Errorf("could create hook request: %w", err)
+		return nil, fmt.Errorf("could create hook request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json; charset=UTF-8")
 
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("could not execute hook request to %s: %w", hr.url, err)
+		return nil, fmt.Errorf("could not execute hook request to %s: %w", hr.url, err)
 	}
 
 	defer res.Body.Close()
@@ -70,26 +103,28 @@ func (hr *hookReconciler) Reconcile(ctx context.Context, obj reconciler.Object) 
 		} else {
 			reserr = string(b)
 		}
-		return fmt.Errorf("hook request at %s returned %d: %s", hr.url, res.StatusCode, reserr)
+		return nil, fmt.Errorf("hook request at %s returned %d: %s", hr.url, res.StatusCode, reserr)
+	}
+
+	// Finalize do not expect data returned
+	if operation == hookv1.OperationFinalize {
+		return nil, nil
 	}
 
 	hres := &hookv1.HookResponse{}
 	err = json.NewDecoder(res.Body).Decode(hres)
 	if err != nil {
-		return fmt.Errorf("hook response from %s could not be parsed: %w", hr.url, err)
+		return nil, fmt.Errorf("hook response from %s could not be parsed: %w", hr.url, err)
 	}
 
-	hr.log.V(5).Info("Response received from hook", "response", *hres)
-
-	// request
-	// if response contains status info, add it.
-	// if response contains env var, add it.
-
-	return nil
+	return hres, nil
 }
 
-func (hr *hookReconciler) Finalize(ctx context.Context, obj reconciler.Object) error {
-	hr.log.V(1).Info("Finalizing at hook", "obj", obj)
+func (hr *hookReconciler) IsReconciler() bool {
+	// For now all hooks are reconcilers
+	return true
+}
 
-	return nil
+func (hr *hookReconciler) IsFinalizer() bool {
+	return hr.isFinalizer
 }

--- a/pkg/reconciler/component/reconciler/interfaces.go
+++ b/pkg/reconciler/component/reconciler/interfaces.go
@@ -95,4 +95,6 @@ type FormFactorReconciler interface {
 type HookReconciler interface {
 	Reconcile(context.Context, Object) error
 	Finalize(context.Context, Object) error
+	IsReconciler() bool
+	IsFinalizer() bool
 }


### PR DESCRIPTION
When a hook that implements the finalizer API is configured, the controlled object instance needs to be updated with the `metadata.finalizer` attributed.

When the object is deleted the hook's finalizer method is called and the attribute is removed.

Closes https://github.com/triggermesh/scoby/issues/50
Closes #49