### PR TITLE
Hooks: add status annotations from hooks

### DIFF
--- a/pkg/reconciler/component/reconciler/base/status/status.go
+++ b/pkg/reconciler/component/reconciler/base/status/status.go
@@ -507,3 +507,27 @@ func (sm *statusManager) SetValue(value interface{}, path ...string) error {
 	sm.ensureStatusRoot()
 	return unstructured.SetNestedField(sm.object.Object, value, path...)
 }
+
+func (sm *statusManager) SetAnnotation(key, value string) error {
+	sm.m.Lock()
+	defer sm.m.Unlock()
+
+	sm.ensureStatusRoot()
+	typedStatus := sm.object.Object["status"].(map[string]interface{})
+
+	annotations, ok := typedStatus["annotations"]
+	if !ok {
+		typedStatus["annotations"] = map[string]string{
+			key: value,
+		}
+		return nil
+	}
+
+	typedAnnotations, ok := annotations.(map[string]interface{})
+	if !ok {
+		return errors.New("unexpected type for status.annotations")
+	}
+
+	typedAnnotations[key] = value
+	return nil
+}

--- a/pkg/reconciler/component/reconciler/hook/reconciler.go
+++ b/pkg/reconciler/component/reconciler/hook/reconciler.go
@@ -53,17 +53,20 @@ func (hr *hookReconciler) Reconcile(ctx context.Context, obj reconciler.Object) 
 	// TODO use status and env vars
 	hr.log.V(5).Info("Response received from hook", "response", *res)
 
-	for _, ev := range res.EnvVars {
-		obj.AddEnvVar(addEnvsPrefix+ev.Name, &ev)
+	for i := range res.EnvVars {
+		obj.AddEnvVar(addEnvsPrefix+res.EnvVars[i].Name, &res.EnvVars[i])
 	}
 
 	if res.Status == nil {
 		return nil
 	}
 
-	for _, st := range res.Status.Conditions {
-		sm := obj.GetStatusManager()
-		sm.SetCondition(&st)
+	sm := obj.GetStatusManager()
+	for i := range res.Status.Conditions {
+		sm.SetCondition(&res.Status.Conditions[i])
+	}
+	for k, v := range res.Status.Annotations {
+		sm.SetAnnotation(k, v)
 	}
 
 	return nil

--- a/pkg/reconciler/component/reconciler/interfaces.go
+++ b/pkg/reconciler/component/reconciler/interfaces.go
@@ -66,6 +66,7 @@ type StatusManager interface {
 	GetAddressURL() string
 	SetAddressURL(string)
 	SetValue(value interface{}, path ...string) error
+	SetAnnotation(key, value string) error
 }
 
 type StatusManagerFactory interface {


### PR DESCRIPTION
Hooks are now able to modify the reconciled object status by adding annotations at `status.annotations`.

This is a fine way of informing users about processes at hooks that do not fit into conditions.