### PR TITLE
Status condition searchable by type

### DIFF
--- a/pkg/apis/common/v1alpha1/status.go
+++ b/pkg/apis/common/v1alpha1/status.go
@@ -62,6 +62,18 @@ type Condition struct {
 // Conditions is the schema for the conditions portion of the payload
 type Conditions []Condition
 
+// Given a type returns a pointer to the condition that holds it,
+// nil if it does not exist.
+func (cs Conditions) GetByType(t string) *Condition {
+	for i := range cs {
+		if cs[i].Type == t {
+			return &cs[i]
+		}
+	}
+
+	return nil
+}
+
 type Status struct {
 	// ObservedGeneration is the 'Generation' of the Object that
 	// was last processed by the controller.

--- a/pkg/apis/common/v1alpha1/status_test.go
+++ b/pkg/apis/common/v1alpha1/status_test.go
@@ -480,3 +480,36 @@ func TestStatusManagerSetCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestConditionByType(t *testing.T) {
+	cs := Conditions{
+		{Type: "condition1"},
+		{Type: "condition2"},
+		{Type: "condition3"},
+	}
+
+	testCases := map[string]struct {
+		conditions    Conditions
+		searchType    string
+		expectedFound bool
+	}{
+		"found": {
+			conditions:    cs,
+			searchType:    "condition1",
+			expectedFound: true,
+		},
+		"not found": {
+			conditions:    cs,
+			searchType:    "condition4",
+			expectedFound: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			res := tc.conditions.GetByType(tc.searchType)
+			assert.True(t, tc.expectedFound == (res != nil), "Condition set and search type do not properly match")
+		})
+	}
+
+}


### PR DESCRIPTION
Add a method to Conditions to make it searchable by type.
This is used at hooks implementations.