### PR TITLE
Fix: panic when there is no add or fromSpec configuration

### DIFF
--- a/cmd/scoby-controller/main.go
+++ b/cmd/scoby-controller/main.go
@@ -17,6 +17,7 @@ import (
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -66,6 +67,9 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme,
+		Cache: cache.Options{
+			Namespaces: []string{scobyconfig.Get().WorkingNamespace()},
+		},
 	})
 	if err != nil {
 		log.Error(err, "unable to create controller manager")

--- a/pkg/component/reconciler/base/renderer/renderer.go
+++ b/pkg/component/reconciler/base/renderer/renderer.go
@@ -63,6 +63,12 @@ func NewRenderer(wkl *commonv1alpha1.Workload, resolver resolver.Resolver, cmr c
 
 	pcfg := wkl.ParameterConfiguration
 	if pcfg == nil {
+		// Add empty structures.
+		// renderer access internal structures that need to be initialized,
+		// so this is sort of a hack to avoid creating methods to access them.
+		r.add, _ = newAddRenderer(nil, nil)
+		r.spec, _ = newSpecRenderer(nil)
+
 		return r, nil
 	}
 
@@ -77,7 +83,7 @@ func NewRenderer(wkl *commonv1alpha1.Workload, resolver resolver.Resolver, cmr c
 
 	r.add = add
 
-	spec, err := newSpecRenderer(pcfg.FromSpec, cmr)
+	spec, err := newSpecRenderer(pcfg.FromSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/component/reconciler/base/renderer/spec_renderer.go
+++ b/pkg/component/reconciler/base/renderer/spec_renderer.go
@@ -7,7 +7,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	commonv1alpha1 "github.com/triggermesh/scoby/pkg/apis/common/v1alpha1"
-	"github.com/triggermesh/scoby/pkg/utils/configmap"
 )
 
 type specRenderer struct {
@@ -28,7 +27,7 @@ type specRenderer struct {
 	volumeByPath map[string]commonv1alpha1.FromSpecToVolume
 }
 
-func newSpecRenderer(speccfg *commonv1alpha1.FromSpecConfiguration, cmr configmap.Reader) (*specRenderer, error) {
+func newSpecRenderer(speccfg *commonv1alpha1.FromSpecConfiguration) (*specRenderer, error) {
 	sr := &specRenderer{
 		allByPath:   make(map[string]struct{}),
 		skipsByPath: make(map[string]struct{}),

--- a/pkg/config/scoby.go
+++ b/pkg/config/scoby.go
@@ -8,6 +8,7 @@ import (
 
 type ScobyConfig interface {
 	ScobyNamespace() string
+	WorkingNamespace() string
 }
 
 // ParseFromEnvironment loads the configuration into a singleton.
@@ -22,7 +23,8 @@ func ParseFromEnvironment() {
 }
 
 type scobyConfig struct {
-	Namespace string `envconfig:"SCOBY_NAMESPACE" required:"true"`
+	ScobyNs   string `envconfig:"SCOBY_NAMESPACE" required:"true"`
+	WorkingNs string `envconfig:"WORKING_NAMESPACE"`
 
 	m sync.RWMutex
 }
@@ -33,7 +35,14 @@ func (sc *scobyConfig) ScobyNamespace() string {
 	sc.m.RLock()
 	defer sc.m.RUnlock()
 
-	return sc.Namespace
+	return sc.ScobyNs
+}
+
+func (sc *scobyConfig) WorkingNamespace() string {
+	sc.m.RLock()
+	defer sc.m.RUnlock()
+
+	return sc.WorkingNs
 }
 
 // Get Scoby configuration


### PR DESCRIPTION
Nil arrays were being iterated when no `add` for `fromSpec` configuration was used.