### PR TITLE
Render: update cm and secret references with path suffix

### DIFF
--- a/config/300-crdregistration.yaml
+++ b/config/300-crdregistration.yaml
@@ -433,7 +433,7 @@ spec:
                                       required:
                                       - name
                                       type: object
-                                    configMap:
+                                    configMapPath:
                                       description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
@@ -453,7 +453,7 @@ spec:
                                       - key
                                       type: object
                                       x-kubernetes-map-type: atomic
-                                    secret:
+                                    secretPath:
                                       description: Selects a key of a secret in the
                                         pod's namespace
                                       properties:

--- a/docs/reference/registration.md
+++ b/docs/reference/registration.md
@@ -106,7 +106,7 @@ Customization for generated parameters is possible through the `spec.workload.pa
 
 The prefix will not be applied to parameters where an explicit name is provided for the environment variable.
 
-### Add New Parameters
+### Add New Environment Variables
 
 - Create new parameter with literal value
 
@@ -173,9 +173,9 @@ The referenced ConfigMap and key must exist.
 
 ### Customize Parameters From Spec
 
-The default behavior is to create parameters from each spec element (arrays will create just one element that includes any sub-elements). When a parameter customization is found, the default parameter generation for that element or any sub-element to the one indicated, will be skipped.
+The default behavior is to create parameters from each element under `spec` found at incoming objects (arrays will create just one element that includes any sub-elements). When a parameter customization is found, the default parameter generation for that element or any sub-element to the one indicated, will be skipped.
 
-- [x] Avoid producing parameter.
+- Avoid producing parameter.
 
 ```yaml
     parameterConfiguration:
@@ -184,7 +184,7 @@ The default behavior is to create parameters from each spec element (arrays will
         - path: spec.bar
 ```
 
-- [x] Change key for generated param. Can be combined.
+- Change key for generated param.
 
 ```yaml
     parameterConfiguration:
@@ -194,17 +194,57 @@ The default behavior is to create parameters from each spec element (arrays will
           name: FOO_BAR
 ```
 
-- [x] Add default value to element when not informed.
+- Use default literal value to element when not informed.
 
 ```yaml
     parameterConfiguration:
       fromSpec:
         toEnv:
         - path: spec.bar
-          defaultValue: hello scoby
+          default:
+            value: hello scoby
 ```
 
-- [x] Generate secret parameter from element.
+- Use default configmap value to element when not informed.
+
+```yaml
+    parameterConfiguration:
+      fromSpec:
+        toEnv:
+        - path: spec.location
+          default:
+            configMap:
+              name: config
+              key: country
+```
+
+- Use default secret value to element when not informed.
+
+```yaml
+    parameterConfiguration:
+      fromSpec:
+        toEnv:
+        - path: spec.username
+          default:
+            secret:
+              name: creds
+              key: user
+```
+
+- Generate configmap parameter from `spec` element.
+
+```yaml
+    parameterConfiguration:
+      fromSpec:
+        toEnv:
+        - path: spec.preferences
+          valueFrom:
+            configMapPath:
+              name: spec.preferences.name
+              key: spec.preferences.key
+```
+
+- Generate secret parameter from `spec` element.
 
 ```yaml
     parameterConfiguration:
@@ -213,25 +253,12 @@ The default behavior is to create parameters from each spec element (arrays will
         - path: spec.credentials
           name: FOO_CREDENTIALS
           valueFrom:
-            secret:
+            secretPath:
               name: spec.credentials.name
               key: spec.credentials.key
 ```
 
-- [x] Generate configmap parameter from element.
-
-```yaml
-    parameterConfiguration:
-      fromSpec:
-        toEnv:
-        - path: spec.preferences
-          valueFrom:
-            configmap:
-              name: spec.preferences.name
-              key: spec.preferences.key
-```
-
-- [x] Function: resolve object to internal URL
+- Function: resolve [addressable object](https://knative.dev/docs/eventing/sinks/) to internal URL
 
 ```yaml
     parameterConfiguration:
@@ -242,6 +269,16 @@ The default behavior is to create parameters from each spec element (arrays will
           valueFrom:
             builtInFunc:
               name: resolveAddress
+```
+
+Addressable objects might be Kubernetes services or references to objects that inform a URL address at `status.address.url`. References at the object instance must follow this structure.
+
+```yaml
+    ref:
+      apiVersion: <APIVERSION REFERENCE>
+      kind: <KIND REFERENCE>
+      name: <OBJECT NAME REFERENCE>
+    uri: <COMPLETE OR PARTIAL URI>
 ```
 
 ### Generate Volumes From Spec

--- a/docs/samples/01.kuard/06.param.secret/01.kuard-registration.yaml
+++ b/docs/samples/01.kuard/06.param.secret/01.kuard-registration.yaml
@@ -22,7 +22,7 @@ spec:
         - path: spec.refToSecret
           name: FOO_CREDENTIALS
           valueFrom:
-            secret:
+            secretPath:
               name: spec.refToSecret.secretName
               key: spec.refToSecret.secretKey
 

--- a/docs/samples/01.kuard/07.param.configmap/01.kuard-registration.yaml
+++ b/docs/samples/01.kuard/07.param.configmap/01.kuard-registration.yaml
@@ -21,7 +21,7 @@ spec:
         # Reference a ConfigMap
         - path: spec.refToConfigMap
           valueFrom:
-            configMap:
+            configMapPath:
               name: spec.refToConfigMap.configName
               key: spec.refToConfigMap.configKey
 

--- a/docs/samples/02.webhooksource/02.webhooksource-registration.yaml
+++ b/docs/samples/02.webhooksource/02.webhooksource-registration.yaml
@@ -40,7 +40,7 @@ spec:
         - path: spec.basicAuthPassword
           name: WEBHOOK_BASICAUTH_PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.basicAuthPassword.valueFromSecret.name
               key: spec.basicAuthPassword.valueFromSecret.key
         - path: spec.eventExtensionAttributes.from

--- a/docs/samples/03.kafkasource/02.kafkasource-registration.yaml
+++ b/docs/samples/03.kafkasource/02.kafkasource-registration.yaml
@@ -42,19 +42,19 @@ spec:
         - path: spec.auth.tls.ca
           name: CA
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.ca.valueFromSecret.name
               key: spec.auth.tls.ca.valueFromSecret.key
         - path: spec.auth.tls.clientCert
           name: CLIENT_CERT
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientCert.valueFromSecret.name
               key: spec.auth.tls.clientCert.valueFromSecret.key
         - path: spec.auth.tls.clientKey
           name: CLIENT_KEY
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientKey.valueFromSecret.name
               key: spec.auth.tls.clientKey.valueFromSecret.key
         - path: spec.auth.username
@@ -62,7 +62,7 @@ spec:
         - path: spec.auth.password
           name: PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.password.valueFromSecret.name
               key: spec.auth.password.valueFromSecret.key
         - path: spec.sink

--- a/docs/samples/05.httptarget/02.httptarget-registration.yaml
+++ b/docs/samples/05.httptarget/02.httptarget-registration.yaml
@@ -48,7 +48,7 @@ spec:
         - path: spec.basicAuthPassword
           name: HTTP_BASICAUTH_PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.credentials.name
               key: spec.preferences.key
         - path: spec.oauthClientID
@@ -56,7 +56,7 @@ spec:
         - path: spec.oauthClientSecret
           name: HTTP_OAUTH_CLIENT_SECRET
           valueFrom:
-            secret:
+            secretPath:
               name: spec.credentials.name
               key: spec.preferences.key
         - path: spec.oauthTokenURL

--- a/docs/samples/06.kafkatarget/02.kafkatarget-registration.yaml
+++ b/docs/samples/06.kafkatarget/02.kafkatarget-registration.yaml
@@ -51,19 +51,19 @@ spec:
         - path: spec.auth.tls.ca
           name: CA
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.ca.valueFromSecret.name
               key: spec.auth.tls.ca.valueFromSecret.key
         - path: spec.auth.tls.clientCert
           name: CLIENT_CERT
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientCert.valueFromSecret.name
               key: spec.auth.tls.clientCert.valueFromSecret.key
         - path: spec.auth.tls.clientKey
           name: CLIENT_KEY
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientKey.valueFromSecret.name
               key: spec.auth.tls.clientKey.valueFromSecret.key
         - path: spec.auth.username
@@ -71,7 +71,7 @@ spec:
         - path: spec.auth.password
           name: PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.password.valueFromSecret.name
               key: spec.auth.password.valueFromSecret.key
 

--- a/docs/triggermesh/README.md
+++ b/docs/triggermesh/README.md
@@ -133,7 +133,7 @@ Given the CRD element to environment variables table above, add this workload pa
         - path: spec.basicAuthPassword
           name: WEBHOOK_BASICAUTH_PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.basicAuthPassword.valueFromSecret.name
               key: spec.basicAuthPassword.valueFromSecret.key
         - path: spec.sink
@@ -216,19 +216,19 @@ Given the CRD element to environment variables table above, add this workload pa
         - path: spec.auth.tls.ca
           name: CA
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.ca.valueFromSecret.name
               key: spec.auth.tls.ca.valueFromSecret.key
         - path: spec.auth.tls.clientCert
           name: CLIENT_CERT
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientCert.valueFromSecret.name
               key: spec.auth.tls.clientCert.valueFromSecret.key
         - path: spec.auth.tls.clientKey
           name: CLIENT_KEY
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientKey.valueFromSecret.name
               key: spec.auth.tls.clientKey.valueFromSecret.key
         - path: spec.auth.username
@@ -236,7 +236,7 @@ Given the CRD element to environment variables table above, add this workload pa
         - path: spec.auth.password
           name: PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.password.valueFromSecret.name
               key: spec.auth.password.valueFromSecret.key
         - path: spec.sink
@@ -323,7 +323,7 @@ Given the CRD element to environment variables table above, add this workload pa
         - path: spec.basicAuthPassword
           name: HTTP_BASICAUTH_PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.credentials.name
               key: spec.preferences.key
         - path: spec.oauthClientID
@@ -331,7 +331,7 @@ Given the CRD element to environment variables table above, add this workload pa
   q     - path: spec.oauthClientSecret
           name: HTTP_OAUTH_CLIENT_SECRET
           valueFrom:
-            secret:
+            secretPath:
               name: spec.credentials.name
               key: spec.preferences.key
         - path: spec.oauthTokenURL
@@ -423,19 +423,19 @@ Given the CRD element to environment variables table above, add this workload pa
         - path: spec.auth.tls.ca
           name: CA
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.ca.valueFromSecret.name
               key: spec.auth.tls.ca.valueFromSecret.key
         - path: spec.auth.tls.clientCert
           name: CLIENT_CERT
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientCert.valueFromSecret.name
               key: spec.auth.tls.clientCert.valueFromSecret.key
         - path: spec.auth.tls.clientKey
           name: CLIENT_KEY
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.tls.clientKey.valueFromSecret.name
               key: spec.auth.tls.clientKey.valueFromSecret.key
         - path: spec.auth.username
@@ -443,7 +443,7 @@ Given the CRD element to environment variables table above, add this workload pa
         - path: spec.auth.password
           name: PASSWORD
           valueFrom:
-            secret:
+            secretPath:
               name: spec.auth.password.valueFromSecret.name
               key: spec.auth.password.valueFromSecret.key
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -564,7 +564,7 @@ spec:
           - path: spec.refToSecret
           name: FOO_CREDENTIALS
           valueFrom:
-            secret:
+            secretPath:
               name: spec.refToSecret.secretName
               key: spec.refToSecret.secretKey
 ```
@@ -635,7 +635,7 @@ kubectl delete secret kuard-secret
 
 ### Parameter Value From ConfigMap
 
-The value for an environment variable can reference a ConfigMap through the `spec.workload.parameterConfiguration.fromSpec[].toEnv.valueFromConfigMap` customization option, that needs the `name` and `key` subelements to be set.
+The value for an environment variable can reference a ConfigMap through the `spec.workload.parameterConfiguration.fromSpec[].toEnv.valueFrom.configMapPath` customization option, that needs the `name` and `key` subelements to be set.
 
 ```yaml
 apiVersion: scoby.triggermesh.io/v1alpha1
@@ -659,7 +659,7 @@ spec:
         # Reference a ConfigMap
         - path: spec.refToConfigMap
           valueFrom:
-            configMap:
+            configMapPath:
               name: spec.refToConfigMap.configName
               key: spec.refToConfigMap.configKey
 ```
@@ -744,7 +744,7 @@ A destination duck type informs either an URI, a Kubernetes service, or a Kubern
     uri: <uri>
 ```
 
-Use the built-in function `spec.workload.parameterConfiguration.fromSpec[].toEnv.valueFromBuiltInFunc.resolveAddress` on the element that contains the Destination type. As an added feature this example also updates an status element with the resolved address.
+Use the built-in function `spec.workload.parameterConfiguration.fromSpec[].toEnv.valueFrom.builtInFunc.resolveAddress` on the element that contains the Destination type. As an added feature this example also updates an status element with the resolved address.
 
 ```yaml
 apiVersion: scoby.triggermesh.io/v1alpha1

--- a/pkg/apis/common/v1alpha1/workload_types.go
+++ b/pkg/apis/common/v1alpha1/workload_types.go
@@ -250,11 +250,11 @@ type SpecToEnvDefaultValue struct {
 type SpecToEnvValueFrom struct {
 	// Selects a key of a ConfigMap.
 	// +optional
-	ConfigMap *corev1.ConfigMapKeySelector `json:"configMap,omitempty"`
+	ConfigMap *corev1.ConfigMapKeySelector `json:"configMapPath,omitempty"`
 
 	// Selects a key of a secret in the pod's namespace
 	// +optional
-	Secret *corev1.SecretKeySelector `json:"secret,omitempty"`
+	Secret *corev1.SecretKeySelector `json:"secretPath,omitempty"`
 
 	// BuiltInFunc configures the field to
 	// be rendered acording to the chosen built-in function.

--- a/pkg/component/reconciler/base/renderer/renderer_test.go
+++ b/pkg/component/reconciler/base/renderer/renderer_test.go
@@ -356,7 +356,7 @@ fromSpec:
   - path: spec.refToSecret
     name: FOO_CREDENTIALS
     valueFrom:
-      secret:
+      secretPath:
         name: spec.refToSecret.secretName
         key: spec.refToSecret.secretKey
 `,
@@ -389,7 +389,7 @@ fromSpec:
   - path: spec.refToConfigMap
     name: FOO_CONFIG
     valueFrom:
-      configMap:
+      configMapPath:
         name: spec.refToConfigMap.configMapName
         key: spec.refToConfigMap.configMapKey
 `,
@@ -452,7 +452,7 @@ fromSpec:
     mountPath: /opt/config
     name: config
     mountFrom:
-      configMap:
+      configMapPath:
         name: spec.refToConfigMap.configMapName
         key: spec.refToConfigMap.configMapKey
 `,
@@ -500,7 +500,7 @@ fromSpec:
     mountPath: /opt/creds
     name: creds
     mountFrom:
-      secret:
+      secretPath:
         name: spec.refToSecret.secretName
         key: spec.refToSecret.secretKey
 `,

--- a/pkg/component/reconciler/base/renderer/renderer_test.go
+++ b/pkg/component/reconciler/base/renderer/renderer_test.go
@@ -452,7 +452,7 @@ fromSpec:
     mountPath: /opt/config
     name: config
     mountFrom:
-      configMapPath:
+      configMap:
         name: spec.refToConfigMap.configMapName
         key: spec.refToConfigMap.configMapKey
 `,
@@ -500,7 +500,7 @@ fromSpec:
     mountPath: /opt/creds
     name: creds
     mountFrom:
-      secretPath:
+      secret:
         name: spec.refToSecret.secretName
         key: spec.refToSecret.secretKey
 `,


### PR DESCRIPTION
Related to https://github.com/triggermesh/scoby/issues/163

Registration elements that refer to ConfigMaps or Secrets through an object path reference now contain the `Path` suffix.
Not yet applied to volume rendering.