### PR TITLE
Render: refactor volumes registration, per item

### DIFF
--- a/config/300-crdregistration.yaml
+++ b/config/300-crdregistration.yaml
@@ -277,12 +277,74 @@ spec:
                                 mountFrom:
                                   description: ValueFrom references an object to mount.
                                   properties:
-                                    configMap:
+                                    configMapPath:
                                       description: Selects a key of a ConfigMap.
                                       properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
+                                        defaultMode:
+                                          description: 'defaultMode is optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
                                         name:
                                           description: 'Name of the referent. More
                                             info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -290,35 +352,90 @@ spec:
                                             kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
                                           type: boolean
-                                      required:
-                                      - key
                                       type: object
                                       x-kubernetes-map-type: atomic
-                                    secret:
+                                    secretPath:
                                       description: Selects a key of a secret in the
                                         pod's namespace
                                       properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
+                                        defaultMode:
+                                          description: 'defaultMode is Optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items If unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
+                                          description: optional field specify whether
+                                            the Secret or its keys must be defined
                                           type: boolean
-                                      required:
-                                      - key
+                                        secretName:
+                                          description: 'secretName is the name of
+                                            the secret in the pod''s namespace to
+                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                   type: object
                                 mountPath:
                                   description: Path where the file will be mounted.
@@ -490,12 +607,74 @@ spec:
                                 mountFrom:
                                   description: ValueFrom references an object to mount.
                                   properties:
-                                    configMap:
+                                    configMapPath:
                                       description: Selects a key of a ConfigMap.
                                       properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
+                                        defaultMode:
+                                          description: 'defaultMode is optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items if unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced ConfigMap will be projected
+                                            into the volume as a file whose name is
+                                            the key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the ConfigMap,
+                                            the volume setup will error unless it
+                                            is marked optional. Paths must be relative
+                                            and may not contain the '..' path or start
+                                            with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
                                         name:
                                           description: 'Name of the referent. More
                                             info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -503,35 +682,90 @@ spec:
                                             kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
                                           type: boolean
-                                      required:
-                                      - key
                                       type: object
                                       x-kubernetes-map-type: atomic
-                                    secret:
+                                    secretPath:
                                       description: Selects a key of a secret in the
                                         pod's namespace
                                       properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
+                                        defaultMode:
+                                          description: 'defaultMode is Optional: mode
+                                            bits used to set permissions on created
+                                            files by default. Must be an octal value
+                                            between 0000 and 0777 or a decimal value
+                                            between 0 and 511. YAML accepts both octal
+                                            and decimal values, JSON requires decimal
+                                            values for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected
+                                            by this setting. This might be in conflict
+                                            with other options that affect the file
+                                            mode, like fsGroup, and the result can
+                                            be other mode bits set.'
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: items If unspecified, each
+                                            key-value pair in the Data field of the
+                                            referenced Secret will be projected into
+                                            the volume as a file whose name is the
+                                            key and content is the value. If specified,
+                                            the listed keys will be projected into
+                                            the specified paths, and unlisted keys
+                                            will not be present. If a key is specified
+                                            which is not present in the Secret, the
+                                            volume setup will error unless it is marked
+                                            optional. Paths must be relative and may
+                                            not contain the '..' path or start with
+                                            '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode
+                                                  bits used to set permissions on
+                                                  this file. Must be an octal value
+                                                  between 0000 and 0777 or a decimal
+                                                  value between 0 and 511. YAML accepts
+                                                  both octal and decimal values, JSON
+                                                  requires decimal values for mode
+                                                  bits. If not specified, the volume
+                                                  defaultMode will be used. This might
+                                                  be in conflict with other options
+                                                  that affect the file mode, like
+                                                  fsGroup, and the result can be other
+                                                  mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative
+                                                  path of the file to map the key
+                                                  to. May not be an absolute path.
+                                                  May not contain the path element
+                                                  '..'. May not start with the string
+                                                  '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
                                         optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
+                                          description: optional field specify whether
+                                            the Secret or its keys must be defined
                                           type: boolean
-                                      required:
-                                      - key
+                                        secretName:
+                                          description: 'secretName is the name of
+                                            the secret in the pod''s namespace to
+                                            use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                          type: string
                                       type: object
-                                      x-kubernetes-map-type: atomic
                                   type: object
                                 mountPath:
                                   description: Path where the file will be mounted.

--- a/docs/reference/registration.md
+++ b/docs/reference/registration.md
@@ -171,7 +171,7 @@ The prefix will not be applied to parameters where an explicit name is provided 
 Permissions for reading ConfigMaps at the controller's namespace must be granted.
 The referenced ConfigMap and key must exist.
 
-### Customize Parameters From Spec
+### Customize Environment Variables From Spec
 
 The default behavior is to create parameters from each element under `spec` found at incoming objects (arrays will create just one element that includes any sub-elements). When a parameter customization is found, the default parameter generation for that element or any sub-element to the one indicated, will be skipped.
 
@@ -281,11 +281,11 @@ Addressable objects might be Kubernetes services or references to objects that i
     uri: <COMPLETE OR PARTIAL URI>
 ```
 
-### Generate Volumes From Spec
+### Mount Volumes From Spec
 
-Secrets and ConfigMaps can be mounted as a volume inside the workload. The registration needs a name for the volume, the file to mount inside the container and a reference to the Secret or ConfigMap.
+Secrets and ConfigMaps can be mounted as a volume inside the workload. The registration needs a name for the volume, the file to mount inside the container and a reference to the Secret or ConfigMap. Refer to kubernetes [volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/) for filling the volume information.
 
-- [x] Function: resolve object to internal URL
+- Mount volume from configmap `spec` element.
 
 ```yaml
     parameterConfiguration:
@@ -293,16 +293,34 @@ Secrets and ConfigMaps can be mounted as a volume inside the workload. The regis
         toVolume:
         - path: spec.userList
           name: userfile
-          mountPath: /opt/user.lst
+          mountPath: /opt/
           mountFrom:
-            configMap:
+            configMapPath:
               name: spec.userList.name
-              key: spec.userList.key
+              items:
+              - path: user.lst
+                key: spec.userList.key
+```
+
+- Mount volume from secret `spec` element
+
+```yaml
+    parameterConfiguration:
+      fromSpec:
+        toVolume:
+        - path: spec.certificates
+          name: certkey
+          mountPath: /opt/cert.key
+          mountFrom:
+            secretPath:
+              secretName: spec.certificates.secretName
+              - path: cert.key
+                key: spec.certificates.secretKey
 ```
 
 ## Workload Status
 
-- [x] Use parameter value for status.
+- Use parameter value for status.
 
 ```yaml
     parameterConfiguration:

--- a/pkg/apis/common/v1alpha1/workload_types.go
+++ b/pkg/apis/common/v1alpha1/workload_types.go
@@ -153,11 +153,11 @@ type AddToVolumeConfiguration struct {
 type MountFrom struct {
 	// Selects a key of a ConfigMap.
 	// +optional
-	ConfigMap *corev1.ConfigMapKeySelector `json:"configMap,omitempty"`
+	ConfigMap *corev1.ConfigMapVolumeSource `json:"configMapPath,omitempty"`
 
 	// Selects a key of a secret in the pod's namespace
 	// +optional
-	Secret *corev1.SecretKeySelector `json:"secret,omitempty"`
+	Secret *corev1.SecretVolumeSource `json:"secretPath,omitempty"`
 }
 
 // FromSpecConfiguration contains instructions to generate rendering from

--- a/pkg/apis/common/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/common/v1alpha1/zz_generated.deepcopy.go
@@ -470,12 +470,12 @@ func (in *MountFrom) DeepCopyInto(out *MountFrom) {
 	*out = *in
 	if in.ConfigMap != nil {
 		in, out := &in.ConfigMap, &out.ConfigMap
-		*out = new(v1.ConfigMapKeySelector)
+		*out = new(v1.ConfigMapVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
 	if in.Secret != nil {
 		in, out := &in.Secret, &out.Secret
-		*out = new(v1.SecretKeySelector)
+		*out = new(v1.SecretVolumeSource)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/pkg/component/reconciler/base/object/object.go
+++ b/pkg/component/reconciler/base/object/object.go
@@ -106,19 +106,19 @@ func (o object) AsPodSpecOptions() []resources.PodSpecOption {
 		switch {
 		case v.MountFrom.ConfigMap != nil:
 			vol = resources.NewVolume(v.Name,
-				resources.VolumeFromConfigMapOption(
-					v.MountFrom.ConfigMap.Name,
-					v.MountFrom.ConfigMap.Key,
-					v.MountPath))
+				resources.VolumeFromConfigMapSourceOption(v.MountFrom.ConfigMap),
+			)
 
 		case v.MountFrom.Secret != nil:
 			vol = resources.NewVolume(v.Name,
-				resources.VolumeFromSecretOption(
-					v.MountFrom.Secret.Name,
-					v.MountFrom.Secret.Key,
-					v.MountPath))
+				resources.VolumeFromSecretSourceOption(v.MountFrom.Secret),
+			)
+
 		}
-		psopts = append(psopts, resources.PodSpecAddVolume(vol))
+
+		if vol != nil {
+			psopts = append(psopts, resources.PodSpecAddVolume(vol))
+		}
 
 		// A VolumeMount matching option is added to the container opts at
 		// the AsContainerOptions function.

--- a/pkg/component/reconciler/base/renderer/renderer_test.go
+++ b/pkg/component/reconciler/base/renderer/renderer_test.go
@@ -449,12 +449,14 @@ add:
 fromSpec:
   toVolume:
   - path: spec.refToConfigMap
-    mountPath: /opt/config
+    mountPath: /opt/
     name: config
     mountFrom:
-      configMap:
+      configMapPath:
         name: spec.refToConfigMap.configMapName
-        key: spec.refToConfigMap.configMapKey
+        items:
+        - path: config
+          key: spec.refToConfigMap.configMapKey
 `,
 			expectedEnvs: []corev1.EnvVar{
 				{Name: "ARRAY", Value: "alpha,beta,gamma"},
@@ -466,7 +468,7 @@ fromSpec:
 			expectedVolMount: []corev1.VolumeMount{
 				{
 					Name:      "config",
-					MountPath: "/opt/config",
+					MountPath: "/opt/",
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -479,7 +481,7 @@ fromSpec:
 							},
 							Items: []corev1.KeyToPath{{
 								Key:  "kuard-cm-key",
-								Path: "/opt/config",
+								Path: "config",
 							}},
 						},
 					},
@@ -497,12 +499,14 @@ fromSpec:
 fromSpec:
   toVolume:
   - path: spec.refToSecret
-    mountPath: /opt/creds
+    mountPath: /opt/
     name: creds
     mountFrom:
-      secret:
-        name: spec.refToSecret.secretName
-        key: spec.refToSecret.secretKey
+      secretPath:
+        secretName: spec.refToSecret.secretName
+        items:
+        - path: creds
+          key: spec.refToSecret.secretKey
 `,
 			expectedEnvs: []corev1.EnvVar{
 				{Name: "ARRAY", Value: "alpha,beta,gamma"},
@@ -514,7 +518,7 @@ fromSpec:
 			expectedVolMount: []corev1.VolumeMount{
 				{
 					Name:      "creds",
-					MountPath: "/opt/creds",
+					MountPath: "/opt/",
 				},
 			},
 			expectedVolumes: []corev1.Volume{
@@ -525,7 +529,7 @@ fromSpec:
 							SecretName: "kuard-sec",
 							Items: []corev1.KeyToPath{{
 								Key:  "kuard-sec-key",
-								Path: "/opt/creds",
+								Path: "creds",
 							}},
 						},
 					},

--- a/pkg/utils/resources/volume.go
+++ b/pkg/utils/resources/volume.go
@@ -47,3 +47,15 @@ func VolumeFromConfigMapOption(cmName, cmKey, mountFile string) VolumeOption {
 		}
 	}
 }
+
+func VolumeFromConfigMapSourceOption(cmvs *corev1.ConfigMapVolumeSource) VolumeOption {
+	return func(v *corev1.Volume) {
+		v.ConfigMap = cmvs
+	}
+}
+
+func VolumeFromSecretSourceOption(svs *corev1.SecretVolumeSource) VolumeOption {
+	return func(v *corev1.Volume) {
+		v.Secret = svs
+	}
+}


### PR DESCRIPTION
Volume registration now is closer to the kubernetes  volume/volumemount structure.

Related to https://github.com/triggermesh/scoby/issues/163
